### PR TITLE
chore(deps): update Gradle to 8.13 and AGP to 8.11.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "8.9.3" apply false
+    id("com.android.application") version "8.11.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 11 18:59:56 WEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary
Updated build tools to the latest stable versions:
- Gradle Wrapper: 8.11.1 → 8.13
- Android Gradle Plugin: 8.9.3 → 8.11.2

### Motivation
Requested by Android Studio to ensure compatibility with the current toolchain.
This change keeps the project aligned with the latest Android build infrastructure.

### Testing
- Successfully built the project locally.
- All existing tests passed.
- Verified manual run in emulator — app works as expected.

### Notes
No functional changes to the app.  
Next step: check for Kotlin and Compose updates in a separate PR.