### PR TITLE
chore(deps): update Gradle to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 11 18:59:56 WEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary
Updated build tools to the latest stable versions:
- Gradle Wrapper: 8.13 → 8.14.3

### Testing
- Successfully built the project locally.
- All existing tests passed.
- Verified manual run in emulator — app works as expected.

### Notes
No functional changes to the app.  
Next step: Merge into master.